### PR TITLE
Date issue fixed

### DIFF
--- a/filedownloadstat/report_stat.py
+++ b/filedownloadstat/report_stat.py
@@ -116,6 +116,9 @@ class ReportStat:
         df = df[~df["year"].isin(skipped_years_list)]
         df_pandas = df.compute()
 
+        # Convert 'date' to Pandas datetime format
+        df_pandas['date'] = pd.to_datetime(df_pandas['date'])
+
         ReportStat.project_stat(df_pandas, baseurl)
         ReportStat.trends_stat(df_pandas)
         ReportStat.regional_stats(df_pandas)

--- a/scripts/.run_stat.sh
+++ b/scripts/.run_stat.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
 ##### VARIABLES
-RUN_NAME="nf-downloadstat-$(echo "$RESOURCE" | tr '[:upper:]' '[:lower:]')-$(date +"%Y")-$(date +"%b" | tr '[:upper:]' '[:lower:]')-$((RANDOM % 9000 + 1000))"
-LOG_FILE="${LOG_FOLDER}${RUN_NAME}_nextflow.log"
+
 RESOURCE=$1
 PROFILE=$2
 API_ENDPOINT_FILE_DOWNLOADS_PER_PROJECT=$3
 API_ENDPOINT_FILE_DOWNLOADS_PER_FILE=$4
 API_ENDPOINT_HEADER=$5
+
+RUN_NAME="nf-downloadstat-$(echo "$RESOURCE" | tr '[:upper:]' '[:lower:]')-$(date +"%Y")-$(date +"%b" | tr '[:upper:]' '[:lower:]')-$((RANDOM % 9000 + 1000))"
+LOG_FILE="${LOG_FOLDER}${RUN_NAME}_nextflow.log"
 
 nextflow -log $LOG_FILE run ${PIPELINE_BASE_DIR}main.nf \
               -params-file params/$RESOURCE-$PROFILE-params.yml \

--- a/scripts/run_stat_local.sh
+++ b/scripts/run_stat_local.sh
@@ -6,17 +6,23 @@ set +a  # Stop automatically exporting variables
 
 ##### VARIABLES
 DATA_ROOT_DIR=$LOGS_DESTINATION_ROOT #"/path/to/data/transfer_logs_privacy_ready"
-RUN_NAME="File-Download-Stat-$(date +"%Y")-$(date +"%b")-$((RANDOM % 9000 + 1000))"
-LOG_FILE="${RUN_NAME}_nextflow.log"
 API_BASE_URL=""
 API_ENDPOINT_FILE_DOWNLOADS_PER_PROJECT=""
 API_ENDPOINT_FILE_DOWNLOADS_PER_FILE=""
 API_ENDPOINT_HEADER=""
 
-PROFILE=$1
+
+RESOURCE=$1
+echo "RESOURCE : ${RESOURCE}"
+PROFILE=$2
+echo "PROFILE : ${PROFILE}"
+
+RUN_NAME="nf-downloadstat-$(echo "$RESOURCE" | tr '[:upper:]' '[:lower:]')-$(date +"%Y")-$(date +"%b" | tr '[:upper:]' '[:lower:]')-$((RANDOM % 9000 + 1000))"
+LOG_FILE="${LOG_FOLDER}${RUN_NAME}_nextflow.log"
+
 conda activate file_download_stat
 nextflow -log $LOG_FILE run ${PIPELINE_BASE_DIR}main.nf \
-              -params-file params/$RESOURCE_NAME-$PROFILE-params.yml \
+              -params-file params/$RESOURCE-$PROFILE-params.yml \
               -name $RUN_NAME \
               -profile $PROFILE \
               --root_dir $DATA_ROOT_DIR \


### PR DESCRIPTION
### Possible Causes
The error suggests that the column date in your df_pandas DataFrame is stored as a date32[day] type from Apache Arrow, which is not directly convertible to Python datetime.

Dask reads Parquet files using Apache Arrow, and sometimes, the date column is stored as date32[day], which causes issues when used in Pandas or Plotly.

### Solution
Convert the date column to a proper Pandas datetime format before using it: